### PR TITLE
update fast-json-patch to the latest version

### DIFF
--- a/keywords/add_keyword.js
+++ b/keywords/add_keyword.js
@@ -9,7 +9,7 @@ module.exports = function (ajv, keyword, jsonPatch, patchSchema) {
       var patch = schema.with;
       if (source.$ref) source = JSON.parse(JSON.stringify(getSchema(source.$ref)));
       if (patch.$ref) patch = getSchema(patch.$ref);
-      jsonPatch.apply(source, patch, true);
+      jsonPatch(source, patch);
       return source;
 
       function getSchema($ref) {

--- a/keywords/merge.js
+++ b/keywords/merge.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var addKeyword = require('./add_keyword');
-var jsonMergePatch = require('json-merge-patch');
+var applyPatch = require('json-merge-patch').apply;
 
 module.exports = function(ajv) {
-  addKeyword(ajv, '$merge', jsonMergePatch, { "type": "object" });
+  addKeyword(ajv, '$merge', applyPatch, { "type": "object" });
 };

--- a/keywords/patch.js
+++ b/keywords/patch.js
@@ -1,10 +1,14 @@
 'use strict';
 
 var addKeyword = require('./add_keyword');
-var jsonPatch = require('fast-json-patch/src/json-patch');
+var jsonPatch = require('fast-json-patch');
+
+function applyPatch (source, patch) {
+  jsonPatch.applyPatch(source, patch, true);
+}
 
 module.exports = function(ajv) {
-  addKeyword(ajv, '$patch', jsonPatch, {
+  addKeyword(ajv, '$patch', applyPatch, {
     "type": "array",
     "items": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/epoberezkin/ajv-merge-patch#readme",
   "dependencies": {
-    "fast-json-patch": "^1.0.0",
+    "fast-json-patch": "^2.0.6",
     "json-merge-patch": "^0.2.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- resolves console warnings produced by the usage of the old version
- standardizes interface expected by add_keyword to be a function taking
  2 arguments - source and patch

Here's the console warning produced by the current version:
```
jsonpatch.apply is deprecated, please use `applyPatch` for applying patch sequences, or `applyOperation` to apply individual operations.
```