### PR TITLE
Update `json-merge-patch` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/epoberezkin/ajv-merge-patch#readme",
   "dependencies": {
     "fast-json-patch": "^2.0.6",
-    "json-merge-patch": "^0.2.3"
+    "json-merge-patch": "^1.0.2"
   },
   "devDependencies": {
     "ajv": "^6.5.1",


### PR DESCRIPTION
The changes seem to be non-breaking, cleanup-only, but they include prototype pollution fixes and a lighter deep-merge dependency. The version currently used by this repo is 6 years old.

https://github.com/pierreinglebert/json-merge-patch/compare/v0.2.3...v1.0.2

I hope to see this and https://github.com/ajv-validator/ajv-merge-patch/pull/39 merged soon ☺️ 