### PR TITLE
handle update to the MissingRegError constructor

### DIFF
--- a/keywords/add_keyword.js
+++ b/keywords/add_keyword.js
@@ -19,7 +19,7 @@ module.exports = function (ajv, keyword, jsonPatch, patchSchema) {
                   : $ref;
         var validate = ajv.getSchema(id);
         if (validate) return validate.schema;
-        throw new ajv.constructor.MissingRefError(it.baseId, $ref);
+        throw new ajv.constructor.MissingRefError(it.opts.uriResolver, it.baseId, $ref);
       }
     },
     metaSchema: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "json-merge-patch": "^1.0.2"
   },
   "devDependencies": {
-    "ajv": "^8.2.0",
+    "ajv": "^8.11.0",
     "coveralls": "^3.1.1",
     "eslint": "^7.8.1",
     "mocha": "^9.0.3",
@@ -45,7 +45,7 @@
     "pre-commit": "^1.1.3"
   },
   "peerDependencies": {
-    "ajv": ">=8.0.0"
+    "ajv": ">=8.10.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Hello, I am trying to run the latest code and I am seeing 
```
1) async schema loading
       $merge
         should load missing schemas:
     TypeError: resolver.resolve is not a function
      at resolveUrl (node_modules/ajv/dist/compile/resolve.js:90:21)
      at new MissingRefError (node_modules/ajv/dist/compile/ref_error.js:7:52)
      ...

  2) async schema loading
       $patch
         should load missing schemas:
     TypeError: resolver.resolve is not a function
      at resolveUrl (node_modules/ajv/dist/compile/resolve.js:90:21)
      at new MissingRefError (node_modules/ajv/dist/compile/ref_error.js:7:52)
      at getSchema (keywords/add_keyword.js:2:1397)
      ...
```
Looks like https://github.com/ajv-validator/ajv/pull/1862 changed the signature of `MissingRefError`.