### PR TITLE
fix: ajv-merge-patch issue 56

### DIFF
--- a/keywords/add_keyword.js
+++ b/keywords/add_keyword.js
@@ -19,7 +19,7 @@ module.exports = function (ajv, keyword, jsonPatch, patchSchema) {
                   : $ref;
         var validate = ajv.getSchema(id);
         if (validate) return validate.schema;
-        throw new ajv.constructor.MissingRefError(it.baseId, $ref);
+        throw new ajv.constructor.MissingRefError(ajv.opts.uriResolver, it.baseId, $ref);
       }
     },
     metaSchema: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "json-merge-patch": "^1.0.2"
   },
   "devDependencies": {
-    "ajv": "^8.2.0",
+    "ajv": "^8.10.0",
     "coveralls": "^3.1.1",
     "eslint": "^7.8.1",
     "mocha": "^9.0.3",
@@ -45,7 +45,7 @@
     "pre-commit": "^1.1.3"
   },
   "peerDependencies": {
-    "ajv": ">=8.0.0"
+    "ajv": ">=8.10.0"
   },
   "nyc": {
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "pre-commit": "^1.1.3"
   },
   "peerDependencies": {
-    "ajv": ">=8.10.0"
+    "ajv": ">=8.0.0"
   },
   "nyc": {
     "exclude": [


### PR DESCRIPTION
Fixes tests with a clean clone.  See https://github.com/ajv-validator/ajv-merge-patch/issues/56